### PR TITLE
Depend on specific version of bit-set from github

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,16 +7,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bit-set"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.5.0"
+source = "git+https://github.com/contain-rs/bit-set?rev=c27082f#c27082fb8a37766909be6e323c0c82a6f8bdfe58"
 dependencies = [
- "bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bit-vec"
@@ -109,7 +104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "rtps-rs"
 version = "0.1.1"
 dependencies = [
- "bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-set 0.5.0 (git+https://github.com/contain-rs/bit-set?rev=c27082f)",
  "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -207,8 +202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-"checksum bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80"
-"checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
+"checksum bit-set 0.5.0 (git+https://github.com/contain-rs/bit-set?rev=c27082f)" = "<none>"
 "checksum bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a4523a10839ffae575fb08aa3423026c8cb4687eef43952afb956229d4f246f7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 time = "0.1.39"
 bytes = "0.5.4"
 tokio-util = { version = "0.2.0", features = ["codec"] }
-bit-set = "0.5.1"
+bit-set = { git = "https://github.com/contain-rs/bit-set", rev ="c27082f" }
 bit-vec = "0.6.1"
 speedy = "0.5.0"
 log = "0.4.8"

--- a/src/structure/locator.rs
+++ b/src/structure/locator.rs
@@ -143,41 +143,41 @@ mod tests {
     }
 
     conversion_test!(
-        {
-            invalid_into_unspecified,
-            Locator_t::LOCATOR_INVALID,
-            SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)
+    {
+        invalid_into_unspecified,
+        Locator_t::LOCATOR_INVALID,
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0)
+    },
+    {
+        non_empty_ipv4,
+        Locator_t {
+            kind: LocatorKind_t::LOCATOR_KIND_UDPv4,
+            address: [
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x7F, 0x00, 0x00, 0x01
+            ],
+            port: 8080
         },
-        {
-            non_empty_ipv4,
-            Locator_t {
-                kind: LocatorKind_t::LOCATOR_KIND_UDPv4,
-                address: [
-                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                    0x7F, 0x00, 0x00, 0x01
-                ],
-                port: 8080
-            },
-            SocketAddr::new(
-                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                8080
-            )
+        SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            8080
+        )
+    },
+    {
+        non_empty_ipv6,
+        Locator_t {
+            kind: LocatorKind_t::LOCATOR_KIND_UDPv6,
+            address: [
+                0xFF, 0x00, 0x45, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x32
+            ],
+            port: 7171
         },
-        {
-            non_empty_ipv6,
-            Locator_t {
-                kind: LocatorKind_t::LOCATOR_KIND_UDPv6,
-                address: [
-                    0xFF, 0x00, 0x45, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x32
-                ],
-                port: 7171
-            },
-            SocketAddr::new(
-                IpAddr::V6(Ipv6Addr::new(0xFF00, 0x4501, 0, 0, 0, 0, 0, 0x0032)),
-                7171
-            )
-        });
+        SocketAddr::new(
+            IpAddr::V6(Ipv6Addr::new(0xFF00, 0x4501, 0, 0, 0, 0, 0, 0x0032)),
+            7171
+        )
+    });
 
     serialization_test!( type = Locator_t,
         {

--- a/src/structure/reliability_kind.rs
+++ b/src/structure/reliability_kind.rs
@@ -13,16 +13,16 @@ mod tests {
     use super::*;
 
     serialization_test!( type = ReliabilityKind_t,
-        {
-            reliability_kind_best_effort,
-            ReliabilityKind_t::BEST_EFFORT,
-            le = [0x01, 0x00, 0x00, 0x00],
-            be = [0x00, 0x00, 0x00, 0x01]
-        },
-        {
-            reliability_kind_reliable,
-            ReliabilityKind_t::RELIABLE,
-            le = [0x02, 0x00, 0x00, 0x00],
-            be = [0x00, 0x00, 0x00, 0x02]
-        });
+    {
+        reliability_kind_best_effort,
+        ReliabilityKind_t::BEST_EFFORT,
+        le = [0x01, 0x00, 0x00, 0x00],
+        be = [0x00, 0x00, 0x00, 0x01]
+    },
+    {
+        reliability_kind_reliable,
+        ReliabilityKind_t::RELIABLE,
+        le = [0x02, 0x00, 0x00, 0x00],
+        be = [0x00, 0x00, 0x00, 0x02]
+    });
 }


### PR DESCRIPTION
bit-set upstream has already upgraded bit-vec dependency. Unfortunately crate is in maintenance mode. I have switched dependency to point directly to latest available commit on GitHub.
